### PR TITLE
fix(functions): changed return of find_missing_datasets to always ret…

### DIFF
--- a/dtcli/ps.py
+++ b/dtcli/ps.py
@@ -69,7 +69,7 @@ def ps(
     try:
         files, policies = functions.ps(scope, dataset, verbose, quiet)
     except Exception as e:
-        logger.error(e)
+        error_console.print(e)
         return None
 
     if show_files and files:

--- a/dtcli/pull.py
+++ b/dtcli/pull.py
@@ -100,7 +100,10 @@ def pull(
     # Find files missing from localhost.
     console.print(f"\nSearching for files for {dataset} {scope}...\n")
     files = find_missing_dataset_files(scope, dataset, directory, verbose)
-    if len(files["missing"]) == 0 and len(files["existing"]) == 0:
+    if files.get("error"):
+        error_console.print(files["error"])
+        return None
+    elif len(files["missing"]) == 0 and len(files["existing"]) == 0:
         console.print("No files found at minoc.", style="bold red")
         return None
     files_paths = [f.replace("cadc:CHIMEFRB", "") for f in files["missing"]]

--- a/dtcli/src/functions.py
+++ b/dtcli/src/functions.py
@@ -221,7 +221,7 @@ def find_missing_dataset_files(
     dataset_locations = get_dataset_file_info(scope, dataset, verbose=verbose)
     if "error" in dataset_locations:
         print(dataset_locations["error"])
-        return {}
+        return {"missing": [], "existing": []}
 
     # check for local copy of the data.
     logger.info("Checking for local copies of files.")

--- a/dtcli/src/functions.py
+++ b/dtcli/src/functions.py
@@ -220,8 +220,7 @@ def find_missing_dataset_files(
     # find dataset
     dataset_locations = get_dataset_file_info(scope, dataset, verbose=verbose)
     if "error" in dataset_locations:
-        print(dataset_locations["error"])
-        return {"missing": [], "existing": []}
+        return {"error": dataset_locations["error"]}
 
     # check for local copy of the data.
     logger.info("Checking for local copies of files.")


### PR DESCRIPTION
…urn a consistent data type. 

Original behaviour:
```
In [4]: x = funcs.get_dataset_file_info('chime.event.intensity.raw', '60011290')

In [5]: print(x)
{'error': 'Could not find 60011290 chime.event.intensity.raw in Datatrail.'}

In [6]: if "error" in x:
   ...:     y = {}
   ...: 

In [7]: print(y)
{}

In [8]:  if len(y["missing"]) == 0 and len(y["existing"]) == 0:
   ...:     print('error')
   ...:  else:
   ...:     print('uncaught')
   ...: 
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ in <module>:1                                                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'missing'
```

New behaviour
```
In [9]: x = funcs.get_dataset_file_info('chime.event.intensity.raw', '60011290')

In [10]: print(x)
{'error': 'Could not find 60011290 chime.event.intensity.raw in Datatrail.'}

In [11]: if "error" in x:
    ...:     y = {"missing": [], "existing": []}
    ...: 

In [12]: print(y)
{'missing': [], 'existing': []}

In [13]: if "error" in x:
    ...:     print('error')
    ...: else:
    ...:     print('uncaught')
    ...: 
error
```