### PR TITLE
🔒 Fix command injection vulnerability in `get_files`

### DIFF
--- a/dtcli/src/functions.py
+++ b/dtcli/src/functions.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import time
 from collections import defaultdict
 from pathlib import Path
@@ -297,8 +298,8 @@ def get_files(
         if site == "canfar":
             for folder in folders:
                 os.makedirs(folder, exist_ok=True)
-                os.system(f"chgrp -R chime-frb-rw {folder}")  # nosec
-                os.system(f"chmod -R g+w {folder}")  # nosec
+                subprocess.run(["chgrp", "-R", "chime-frb-rw", folder])
+                subprocess.run(["chmod", "-R", "g+w", folder])
         else:
             for folder in folders:
                 os.makedirs(folder, exist_ok=True)


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `dtcli/src/functions.py`.
⚠️ **Risk:** The previous implementation used `os.system` with string interpolation for `chgrp` and `chmod` commands, making it susceptible to command injection if folder paths contained shell metacharacters.
🛡️ **Solution:** Replaced `os.system` with `subprocess.run`, passing the command arguments as a list. This prevents shell execution of arbitrary commands embedded in folder paths.

---
*PR created automatically by Jules for task [13490696024129705762](https://jules.google.com/task/13490696024129705762) started by @tjzegmott*