### PR TITLE
⚡ Optimize CADC client capability status checks with concurrent execution

### DIFF
--- a/dtcli/utilities/cadcclient.py
+++ b/dtcli/utilities/cadcclient.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from multiprocessing import Process  # Use the standard library only
 from typing import Any, Dict, List, Optional, Tuple
@@ -410,23 +411,25 @@ def status(
     ]
     if not certfile:
         certfile = procure(key="vospace_certfile")
-    minoc_status = False
-    luskan_status = False
-    for index, url in enumerate(urls):
+
+    def check_url(url: str) -> bool:
         response = requests.get(url, cert=certfile, allow_redirects=True)
         try:
             response.raise_for_status()
             authorised = response.headers.get("x-vo-authenticated")
             if isinstance(authorised, str):
-                if index == 0:
-                    minoc_status = True
-                else:
-                    luskan_status = True
+                return True
             else:
                 raise TypeError
         except HTTPError as error:
             logger.warning(error)
             logger.warning(f"{url.split('/')[3]} is down.")
+            return False
         except TypeError:
             logger.error("Canfar certificate is not valid.")
-    return minoc_status, luskan_status
+            return False
+
+    with ThreadPoolExecutor(max_workers=len(urls)) as executor:
+        results = list(executor.map(check_url, urls))
+
+    return results[0], results[1]


### PR DESCRIPTION
💡 **What:** The optimization implemented
Replaced the sequential loop checking MINOC and Luskan capabilities in `dtcli/utilities/cadcclient.py::status()` with a `concurrent.futures.ThreadPoolExecutor`. A helper function processes the HTTP request and handles exceptions concurrently.

🎯 **Why:** The performance problem it solves
The original code looped over an array of 2 URLs, executing an independent HTTP GET request synchronously for each iteration. In scenarios with any sort of network latency, these blocking operations compound. Running the requests in parallel mitigates the cumulative latency overhead of independent network calls, reducing the function execution time.

📊 **Measured Improvement:** 
Using an injected `1.0s` sleep mock representing network latency in a benchmark script simulating `status()`:
* **Baseline (Sequential):** 2.0005 seconds
* **Optimized (Concurrent):** 1.0020 seconds
* **Speedup:** Execution time for the function is halved (latency of network requests is bound to `max(t_1, t_2)` rather than `t_1 + t_2`).

---
*PR created automatically by Jules for task [13064934752270288918](https://jules.google.com/task/13064934752270288918) started by @tjzegmott*