### PR TITLE
fix(unregistered): improve way info displayed

### DIFF
--- a/dtcli/src/functions.py
+++ b/dtcli/src/functions.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import subprocess
 import time
-from collections import defaultdict
+from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -486,6 +486,15 @@ def get_unregistered_dataset(dataset: str, scope: str) -> Optional[Dict[str, Any
         return response[0]
 
 
+ATTACH_RE = re.compile(
+    r"Could not attach datasets: .+? ERROR: \"?dataset (.+?), (.+?) not found"  # noqa: E501
+)
+
+CREATE_RE = re.compile(
+    r"Could not create dataset: (.+?), scope: (.+?)\. .*UniqueViolation"  # noqa: E501
+)
+
+
 def signature(msg: str) -> str:
     """Create a signature for a reason unregistered message.
 
@@ -495,16 +504,6 @@ def signature(msg: str) -> str:
     Returns:
         str: Signature for error message.
     """
-    ATTACH_RE = re.compile(
-        r"Could not attach datasets: .+ ERROR: dataset (.+), (.+) not found"  # noqa: E501
-    )
-
-    CREATE_RE = re.compile(
-        r"Could not create dataset: (.+), scope: (.+)\. .*UniqueViolation"  # noqa: E501
-    )
-
-    POSTGRES_RE = re.compile(r".*psycopg.*")
-
     msg = msg.strip()
 
     # Attach-dataset errors
@@ -517,11 +516,12 @@ def signature(msg: str) -> str:
     m = CREATE_RE.search(msg)
     if m:
         dataset, scope = m.groups()
+        dataset = re.sub(r"\d+", "<ID>", dataset)
         return f"CREATE_DUPLICATE:{dataset}:{scope}"
 
     # PostgreSQL violation
-    m = POSTGRES_RE.search(msg)
-    if m:
+    if "psycopg" in msg:
+        msg = re.sub(r"\s+", " ", msg)
         return f"POSTGRES:{msg[:120]}"
 
     # Short status / token messages
@@ -552,11 +552,4 @@ def summarise_unregistered_datasets() -> Dict[str, int]:
         Dict[str, int]: Dictionary of error message signatures and their counts.
     """
     response = get_all_unregistered_datasets()
-    reason_groups: Dict[str, int] = defaultdict(int)
-    messages = [str(r["results"]["reason"]) for r in response]
-
-    for msg in messages:
-        sig = signature(msg)
-        reason_groups[sig] += 1
-
-    return reason_groups
+    return Counter(signature(str(r["results"]["reason"])) for r in response)

--- a/dtcli/unregistered.py
+++ b/dtcli/unregistered.py
@@ -1,10 +1,13 @@
 """Datatrail Unregistered datasets commands."""
 
 import logging
+from collections import defaultdict
+from typing import DefaultDict, List, Tuple
 
 import click
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from dtcli.src import functions
 from dtcli.utilities.utilities import set_log_level
@@ -13,6 +16,14 @@ logger = logging.getLogger(__name__)
 
 console = Console()
 error_console = Console(stderr=True, style="bold red")
+
+CATEGORY_STYLES = {
+    "ATTACH_MISSING": "yellow",
+    "CREATE_DUPLICATE": "magenta",
+    "POSTGRES": "red",
+    "OTHER": "red",
+    "STATUS": "cyan",
+}
 
 
 @click.group(help="Commands related to unregistered datasets.")
@@ -45,17 +56,47 @@ def summary(
 
     results = functions.summarise_unregistered_datasets()
 
+    if not results:
+        console.print("No unregistered datasets found.")
+        return
+
+    total = sum(results.values())
+
     table = Table(
-        title="Summary of reasons",
+        title=f"Summary of reasons — {total:,} unregistered datasets",
         header_style="magenta",
         title_style="bold magenta",
+        row_styles=["none", "dim"],
     )
-    table.add_column("Reason")
-    table.add_column("Number of Datasets")
+    table.add_column("Category")
+    table.add_column("Detail")
+    table.add_column("Count", justify="right")
+    table.add_column("%", justify="right")
 
-    for key, value in sorted(results.items(), key=lambda x: x[1], reverse=True):
-        table.add_row(key, str(value))
+    # Group signatures by their category prefix, e.g. "ATTACH_MISSING:...".
+    groups: DefaultDict[str, List[Tuple[str, int]]] = defaultdict(list)
+    for sig, count in results.items():
+        category, _, detail = sig.partition(":")
+        groups[category].append((detail, count))
 
-    table.row_styles = ["none", "dim"]
+    ordered = sorted(
+        groups.items(),
+        key=lambda group: sum(count for _, count in group[1]),
+        reverse=True,
+    )
+    for index, (category, reasons) in enumerate(ordered):
+        if index:
+            table.add_section()
+        style = CATEGORY_STYLES.get(category, "white")
+        reasons.sort(key=lambda reason: reason[1], reverse=True)
+        for row, (detail, count) in enumerate(reasons):
+            if category in ("ATTACH_MISSING", "CREATE_DUPLICATE"):
+                detail = detail.replace(":", " → ", 1)
+            table.add_row(
+                Text(category, style=style) if row == 0 else "",
+                Text(detail) if detail else "(no reason recorded)",
+                f"{count:,}",
+                f"{count / total:.1%}",
+            )
 
     console.print(table)


### PR DESCRIPTION
```bash
❯ uv run datatrail unregistered summary
                                                       Summary of reasons — 5,548 unregistered datasets
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┓
┃ Category         ┃ Detail                                                                                                                   ┃ Count ┃     % ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━┩
│ ATTACH_MISSING   │ outrigger.commissioning.B2020 → chime.event.intensity.raw                                                                │ 4,105 │ 74.0% │
│                  │ outrigger.commissioning.B0834 → chime.event.intensity.raw                                                                │   370 │  6.7% │
│                  │ outrigger.commissioning.B0611 → chime.event.intensity.raw                                                                │   189 │  3.4% │
│                  │ outrigger.commissioning.B0834 → kko.event.baseband.raw                                                                   │    12 │  0.2% │
│                  │ outrigger.commissioning.B0834 → chime.event.baseband.raw                                                                 │    12 │  0.2% │
│                  │ outrigger.commissioning.B0834 → hco.event.baseband.raw                                                                   │    12 │  0.2% │
│                  │ outrigger.commissioning.B0834 → gbo.event.baseband.raw                                                                   │    12 │  0.2% │
│                  │ outrigger.commissioning.B2020 → kko.event.baseband.raw                                                                   │     2 │  0.0% │
│                  │ outrigger.commissioning.B2020 → chime.event.baseband.raw                                                                 │     2 │  0.0% │
│                  │ outrigger.commissioning.B2020 → hco.event.baseband.raw                                                                   │     2 │  0.0% │
│                  │ outrigger.commissioning.B2020 → gbo.event.baseband.raw                                                                   │     2 │  0.0% │
│                  │ event-missing-verification → chime.event.baseband.raw                                                                    │     1 │  0.0% │
├──────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼───────┤
│ POSTGRES         │ (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "name_se_captured_at_pair" DETAIL: Key  │   627 │ 11.3% │
│                  │ (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring p │     1 │  0.0% │
├──────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼───────┤
│ STATUS           │ (no reason recorded)                                                                                                     │    93 │  1.7% │
│                  │ event-missing-verification                                                                                               │    85 │  1.5% │
│                  │ pending-tsar-classification                                                                                              │    17 │  0.3% │
├──────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼───────┤
│ CREATE_DUPLICATE │ <ID> → chime.event.baseband.raw                                                                                          │     3 │  0.1% │
├──────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼───────┤
│ OTHER            │ (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.UniqueViolationError'>: duplicate key │     1 │  0.0% │
└──────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────┴───────┘
```